### PR TITLE
No esconder menu al estar escribiendo materias

### DIFF
--- a/js/organizador.js
+++ b/js/organizador.js
@@ -1277,7 +1277,8 @@
       });
 	  
 	  $("#box2").mouseleave(function(){
-		$("#buscar").prop('disabled', true);
+        if ($("#buscar").is(':focus')) return;
+	  	$("#buscar").prop('disabled', true);
 		$("#box2").stop();
         $("#box2").animate({right: '-488px'});
       });


### PR DESCRIPTION
Me parecía medio molesto el estar escribiendo el nombre de una materia y si se me corría el mouse se me escondía el menu de busqueda. Propongo este simple if para evitarlo.